### PR TITLE
Update pulumi-terraform to 3635bed3a5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.0.0 // indirect
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d
+	github.com/pulumi/pulumi-terraform v0.18.3
 	github.com/rogpeppe/fastuuid v1.1.0 // indirect
 	github.com/russross/blackfriday v2.0.0+incompatible // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -622,6 +622,8 @@ github.com/pulumi/pulumi-terraform v0.15.1/go.mod h1:j1Hb86i+cujAPoQwDRPlZa6T6cM
 github.com/pulumi/pulumi-terraform v0.18.2 h1:87eFAASBmHCH41OlcGZAydGgSYFTIPFoKjzaJ8Edw5M=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d h1:ObOJbSfTnJ8IzrTw7pVcckU+R0yMEyV4mXdQ+xH+j8w=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
+github.com/pulumi/pulumi-terraform v0.18.3 h1:DHpETa+TWnthH9Sw3bHS+HxSgidB1cASkVqtQTW8jxg=
+github.com/pulumi/pulumi-terraform v0.18.3/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -21,13 +21,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-    $ npm install @pulumi/postgresql
+   $ npm install @pulumi/postgresql
 
 or ``yarn``:
 
 ::
 
-    $ yarn add @pulumi/postgresql
+   $ yarn add @pulumi/postgresql
 
 Python
 ~~~~~~
@@ -36,7 +36,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-    $ pip install pulumi_postgresql
+   $ pip install pulumi_postgresql
 
 Go
 ~~
@@ -45,7 +45,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-    $ go get github.com/pulumi/pulumi-postgresql/sdk/go/...
+   $ go get github.com/pulumi/pulumi-postgresql/sdk/go/...
 
 Configuration
 -------------

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -21,13 +21,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-   $ npm install @pulumi/postgresql
+    $ npm install @pulumi/postgresql
 
 or ``yarn``:
 
 ::
 
-   $ yarn add @pulumi/postgresql
+    $ yarn add @pulumi/postgresql
 
 Python
 ~~~~~~
@@ -36,7 +36,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-   $ pip install pulumi_postgresql
+    $ pip install pulumi_postgresql
 
 Go
 ~~
@@ -45,7 +45,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-   $ go get github.com/pulumi/pulumi-postgresql/sdk/go/...
+    $ go get github.com/pulumi/pulumi-postgresql/sdk/go/...
 
 Configuration
 -------------


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [3635bed3a5](https://github.com/pulumi/pulumi-terraform/commit/3635bed3a5c0250c3b22f02fde7845acd0dce3b6), and re-runs code generation