### PR TITLE
Update pulumi-terraform to 08d502e9b4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/kr/pty v1.1.5 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect
-	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/miekg/dns v1.0.14 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
@@ -50,8 +49,8 @@ require (
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.0.0 // indirect
-	github.com/pulumi/pulumi v0.17.22-0.20190702185104-ebceea93a5da
-	github.com/pulumi/pulumi-terraform v0.18.4-0.20190709052202-629f7c54269d
+	github.com/pulumi/pulumi v0.17.23-0.20190715212628-02ffff88409f
+	github.com/pulumi/pulumi-terraform v0.18.4-0.20190716112909-08d502e9b427
 	github.com/rogpeppe/fastuuid v1.1.0 // indirect
 	github.com/russross/blackfriday v2.0.0+incompatible // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -673,6 +673,8 @@ github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0 h1:NqGT9rxjyADqq2
 github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0/go.mod h1:RIy1gmz8Vyy7H5w2ffHJ23aZHCOggF2zk2c+KD1GMtY=
 github.com/pulumi/pulumi v0.17.22-0.20190702185104-ebceea93a5da h1:8j8kMQncrqAfspsfmmjcEQVzeWYDYFHF8O545CcXEG4=
 github.com/pulumi/pulumi v0.17.22-0.20190702185104-ebceea93a5da/go.mod h1:YUZl+EG25I3Zs337/O7gRiGfquphPBOrMG6QZYAWW9g=
+github.com/pulumi/pulumi v0.17.23-0.20190715212628-02ffff88409f h1:3K/cssb6A3pEEDcNPEZSOVF70jPIdgftGX9UcSINZ/0=
+github.com/pulumi/pulumi v0.17.23-0.20190715212628-02ffff88409f/go.mod h1:d+ivoM5WASR34nx+EJwBMfWtuU8oczAY5lMTrXsdboM=
 github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190506205940-21108d2d0be2 h1:VdG9S3rFg7tbmsR3gY3pKmTFaKgBw4vyyEdoldHs9aY=
 github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190506205940-21108d2d0be2/go.mod h1:bJ2tsYQlSMzMCEDb2kP1rDHaadG3O7JUnBUYH/yx2Io=
 github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190514181826-fbd8ddbea29e h1:Fa61W5s7Xb3TxHNSoHNi8SjpYHxf/cOf7UysjWSPEgA=
@@ -690,6 +692,8 @@ github.com/pulumi/pulumi-terraform v0.18.4-0.20190703150544-a9a9ca8157ca h1:Zj43
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190703150544-a9a9ca8157ca/go.mod h1:5QshR5Q/a3gJiSPx1d+AblvcvfJCYC7255q8DtnvJv4=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190709052202-629f7c54269d h1:Pmw7a8wXD20fcgekI6U5QiX4IzRFcaj9YSUgE/LMV5s=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190709052202-629f7c54269d/go.mod h1:5QshR5Q/a3gJiSPx1d+AblvcvfJCYC7255q8DtnvJv4=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190716112909-08d502e9b427 h1:zCNael1dbtaWcWWXdoxChRaFaXeKDu2F4dycNr/rT5A=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190716112909-08d502e9b427/go.mod h1:HZZfntNPhurepaYfYpimuN4KGSuEJm6/EUOopwS8oUM=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=

--- a/sdk/go/postgresql/_about.go
+++ b/sdk/go/postgresql/_about.go
@@ -1,0 +1,8 @@
+//nolint: lll
+// Package postgresql exports types, functions, subpackages for provisioning postgresql resources.
+//
+// > This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-postgresql)
+// > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
+// > first check the [`pulumi/pulumi-postgresql` repo](https://github.com/pulumi/pulumi-postgresql/issues); however, if that doesn't turn up anything,
+// > please consult the source [`terraform-providers/terraform-provider-postgresql` repo](https://github.com/terraform-providers/terraform-provider-postgresql/issues).
+package postgresql

--- a/sdk/go/postgresql/config/_about.go
+++ b/sdk/go/postgresql/config/_about.go
@@ -1,0 +1,8 @@
+//nolint: lll
+// Package config exports types, functions, subpackages for provisioning config resources.
+//
+// > This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-postgresql)
+// > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
+// > first check the [`pulumi/pulumi-postgresql` repo](https://github.com/pulumi/pulumi-postgresql/issues); however, if that doesn't turn up anything,
+// > please consult the source [`terraform-providers/terraform-provider-postgresql` repo](https://github.com/terraform-providers/terraform-provider-postgresql/issues).
+package config


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [08d502e9b4](https://github.com/pulumi/pulumi-terraform/commit/08d502e9b427397307d268c0d0343499452717a9), and re-runs code generation