### PR TITLE
Enable zero default schema version for postgresql

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -137,6 +137,7 @@ func Provider() tfbridge.ProviderInfo {
 				mainPkg: "PostgreSql",
 			},
 		},
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	prov.RenameResourceWithAlias("postgresql_default_privileges", makeResource(mainMod, "DefaultPrivileg"),


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133

Enables zero default schema version for postgresql.