### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -133,6 +133,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	prov.RenameResourceWithAlias("postgresql_default_privileges", makeResource(mainMod, "DefaultPrivileg"),


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the provider.

part of pulumi/pulumi-terraform-bridge#2598